### PR TITLE
chore: upgrade prisma to 2.10.1

### DIFF
--- a/.github/workflows/grading-app.yaml
+++ b/.github/workflows/grading-app.yaml
@@ -33,7 +33,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       # run the migration in the test database
-      - run: npm run migrate:up
+      - run: npm run db:push
       - run: npm run test
   deploy:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,19 +1167,40 @@
         "chalk": "^3.0.0"
       }
     },
-    "@prisma/cli": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.7.0.tgz",
-      "integrity": "sha512-OCiTV6Xs9GHUk4iJGQeJizyUyrm7pnKCjoeulN+OXAdbfkLwNlRC+/H/8aOwcXx+Nej/QgXoix9CGcs+OYrdnA==",
+    "@prisma/bar": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/bar/-/bar-0.0.0.tgz",
+      "integrity": "sha512-3nez9n/vMyAr4+nmqj6Xh3cGZbreYHr3RWX0vgtrFRpiN6otuCzL+9HW8MW/DfZNuFz5YyIdfwnRSPueUZPoWQ==",
       "dev": true
     },
-    "@prisma/client": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.7.0.tgz",
-      "integrity": "sha512-9QkicjHSJwRa05eYdm4J4T3UXdF9SfRboQ8eCvrExOkvl1bhEEeACv0D4dGdmbxr2O/xAwUAW5T9XdJnzOQmGw==",
+    "@prisma/cli": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.10.1.tgz",
+      "integrity": "sha512-I+51GBJyuGS5xsCl8pf4XfTt9HIdhCJQoaGCA9KLDzVRbFHElMQ++hhyhLohJ4buFZlSagIq8NI8yIC5yu+Wkg==",
+      "dev": true,
       "requires": {
-        "pkg-up": "^3.1.0"
+        "@prisma/bar": "^0.0.0",
+        "@prisma/engines": "2.10.1-6-7d0087eadc7265e12d4b8d8c3516b02c4c965111"
       }
+    },
+    "@prisma/client": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.10.1.tgz",
+      "integrity": "sha512-VwasxCCwdRmrcVVoLwXTEbwrBiqOYr2Umqw9btvMvHGRhA1nRKCvmt7SCiCjGrx6CuC8eCG/HGxruv04001YKQ==",
+      "requires": {
+        "@prisma/engines-version": "2.10.1-6-7d0087eadc7265e12d4b8d8c3516b02c4c965111"
+      }
+    },
+    "@prisma/engines": {
+      "version": "2.10.1-6-7d0087eadc7265e12d4b8d8c3516b02c4c965111",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.10.1-6-7d0087eadc7265e12d4b8d8c3516b02c4c965111.tgz",
+      "integrity": "sha512-F/I8mmYMQnEFX47jl7Su8Pmvpua1wti9Uq3IUlSCqLQsrOmuMj+GKQ5nYEewmcynqBlyVcpUyxF5iAWbmUVdjw==",
+      "dev": true
+    },
+    "@prisma/engines-version": {
+      "version": "2.10.1-6-7d0087eadc7265e12d4b8d8c3516b02c4c965111",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.10.1-6-7d0087eadc7265e12d4b8d8c3516b02c4c965111.tgz",
+      "integrity": "sha512-OuOSTvEzXJwCJzNqZ9N/+J3lO64HgX9uGiVOuvlTrRSXoLZk0Q2IiLAx8qhY1U7jPpHJ7LTlZuGNScimqonpJg=="
     },
     "@sendgrid/client": {
       "version": "7.3.0",
@@ -5561,6 +5582,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -5577,7 +5599,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "parse-json": {
       "version": "5.1.0",
@@ -5744,46 +5767,6 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
-      }
-    },
-    "pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "requires": {
-        "find-up": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        }
       }
     },
     "posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@hapi/boom": "^9.1.0",
     "@hapi/hapi": "^20.0.1",
     "joi": "^17.3.0",
-    "@prisma/client": "2.7.0",
+    "@prisma/client": "2.10.1",
     "@sendgrid/mail": "^7.3.0",
     "date-fns": "^2.16.1",
     "dotenv": "^8.2.0",
@@ -15,7 +15,7 @@
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
-    "@prisma/cli": "2.7.0",
+    "@prisma/cli": "2.10.1",
     "@types/hapi-pino": "^8.0.1",
     "@types/hapi__hapi": "^20.0.1",
     "@types/jest": "^26.0.9",
@@ -36,6 +36,7 @@
     "test": "TEST=true jest",
     "test:watch": "TEST=true jest --watch",
     "postgres:start": "docker-compose up -d",
+    "db:push": "prisma db push --preview-feature --ignore-migrations",
     "migrate:save": "prisma migrate --experimental save",
     "migrate:up": "prisma migrate --experimental up --auto-approve --create-db",
     "prisma:generate": "prisma generate"


### PR DESCRIPTION

Use the new `prisma db push` command to migrate the database schema for tests